### PR TITLE
Sync name in package-lock.json to match package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "sole-and-ankle",
+  "name": "sole-and-ankle-revisited",
   "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,


### PR DESCRIPTION
Sync `name` in package-lock.json to match package.json. A small change. Thank you @joshwcomeau for your great workshop!